### PR TITLE
Sanitize usage of group's list value

### DIFF
--- a/Classes/Module/DmailController.php
+++ b/Classes/Module/DmailController.php
@@ -1573,11 +1573,11 @@ class DmailController extends MainController
                         break;
                     case 1:
                         // List of mails
+                        $mailGroupList = (string)$mailGroup['list'];
                         if ($mailGroup['csv'] == 1) {
                             $dmCsvUtility = GeneralUtility::makeInstance(DmCsvUtility::class);
-                            $recipients = $dmCsvUtility->rearrangeCsvValues($dmCsvUtility->getCsvValues($mailGroup['list']), $this->fieldList);
+                            $recipients = $dmCsvUtility->rearrangeCsvValues($dmCsvUtility->getCsvValues($mailGroupList), $this->fieldList);
                         } else {
-                            $mailGroupList = $mailGroup['list'];
                             $recipients = $mailGroupList ? $this->rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
                         }
                         $idLists['PLAINLIST'] = $this->cleanPlainList($recipients);

--- a/Classes/Module/RecipientListController.php
+++ b/Classes/Module/RecipientListController.php
@@ -285,11 +285,11 @@ class RecipientListController extends MainController
                         break;
                     case 1:
                         // List of mails
+                        $mailGroupList = (string)$mailGroup['list'];
                         if ($mailGroup['csv'] == 1) {
                             $dmCsvUtility = GeneralUtility::makeInstance(DmCsvUtility::class);
-                            $recipients = $dmCsvUtility->rearrangeCsvValues($dmCsvUtility->getCsvValues($mailGroup['list']), $this->fieldList);
+                            $recipients = $dmCsvUtility->rearrangeCsvValues($dmCsvUtility->getCsvValues($mailGroupList), $this->fieldList);
                         } else {
-                            $mailGroupList = $mailGroup['list'];
                             $recipients = $mailGroupList ? $this->rearrangePlainMails(array_unique(preg_split('|[[:space:],;]+|', $mailGroupList))) : [];
                         }
                         $idLists['PLAINLIST'] = $this->cleanPlainList($recipients);


### PR DESCRIPTION
Had issues w/ "Direct Mail" and "Recipient Lists" BE modules due to group entries containing NULL values for list. Because of strict_types declaration values should be cast to string.