### PR TITLE
[BUGFIX] Add default value for sys_dmail_group.title

### DIFF
--- a/Configuration/TCA/sys_dmail_group.php
+++ b/Configuration/TCA/sys_dmail_group.php
@@ -28,6 +28,7 @@ return [
                 'max' => '120',
                 'required' => true,
                 'eval' => 'trim',
+                'default' => '',
             ],
         ],
         'description' => [


### PR DESCRIPTION
Fixes error: SQL error: "Field 'title' doesn't have a default value"

1. Create new sys_dmail_group record
2. Change type (without saving beforehand)
3. Do refresh as suggested in overlay

Expected: updated type field
Actual result: SQL error: "Field 'title' doesn't have a default value"