### PR TITLE
Fix recursive flaq in recipient list

### DIFF
--- a/Classes/Module/MainController.php
+++ b/Classes/Module/MainController.php
@@ -443,7 +443,7 @@ class MainController
         $getLevels = 10000;
         // Finding tree and offer setting of values recursively.
         $tree = GeneralUtility::makeInstance(PageTreeView::class);
-        $tree->init('AND ' . $perms_clause);
+        $tree->init(empty($perms_clause) ? ''  : 'AND ' . $perms_clause);
         $tree->makeHTML = 0;
         $tree->setRecs = 0;
         $tree->getTree($id, $getLevels, '');


### PR DESCRIPTION
This prevents a broken sql query.

In case of an admin the permission clause is empty. 

Reproduce: Create recipient list from pages and check the recursive flaq. Then visit the recipient list module